### PR TITLE
Patch 1

### DIFF
--- a/jsfinder.go
+++ b/jsfinder.go
@@ -182,7 +182,11 @@ func main() {
 									}
 								} else {
 									if strings.HasPrefix(jsURL, "/") {
-										file.WriteString(fmt.Sprintf("%s%s\n", url, jsURL))
+										if strings.HasSuffix(url,"/") {
+											file.WriteString(fmt.Sprintf("%s%s\n",url,strings.TrimPrefix(jsUrl,"/")))
+										} else {
+											file.WriteString(fmt.Sprintf("%s%s\n", url, jsURL))
+										}
 									} else if strings.HasPrefix(jsURL, "https://") || strings.HasPrefix(jsURL, "http://") {
 										file.WriteString(fmt.Sprintf("%s\n", jsURL))
 									} else if strings.HasPrefix(jsURL, "//") {

--- a/jsfinder.go
+++ b/jsfinder.go
@@ -211,10 +211,20 @@ func main() {
 								file.WriteString(fmt.Sprintf("https://%s/%s\n", jsURL[:strings.Index(jsURL, ".")+4], jsURL[strings.Index(jsURL, ".")+4:]))
 							}
 						} else {
-							file.WriteString(fmt.Sprintf("%s/%s\n", url, jsURL))
+							if strings.HasPrefix(jsURL, "/") {
+										if strings.HasSuffix(url,"/") {
+											file.WriteString(fmt.Sprintf("%s%s\n",url,strings.TrimPrefix(jsUrl,"/")))
+										} else {
+											file.WriteString(fmt.Sprintf("%s%s\n", url, jsURL))
+										}
 						}
 					} else {
-						file.WriteString(fmt.Sprintf("%s/%s\n", url, jsURL))
+							if strings.HasPrefix(jsURL, "/") {
+										if strings.HasSuffix(url,"/") {
+											file.WriteString(fmt.Sprintf("%s%s\n",url,strings.TrimPrefix(jsUrl,"/")))
+										} else {
+											file.WriteString(fmt.Sprintf("%s%s\n", url, jsURL))
+										}
 					}
 				}
 


### PR DESCRIPTION
old snippet would have allowed javascript links to have double slashes which wouldn't be a valid js file in few cases 

Test case -> 
jsUrl = /testing.js
url = https://imspaceboy.com/
end result will be https://imspaceboy.com//testing.js

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/46881b9a-b5de-4c1c-aa7f-1a851a2d63c5">
